### PR TITLE
style: cargo fmt baseline across src/

### DIFF
--- a/src/candle_indicators.rs
+++ b/src/candle_indicators.rs
@@ -1,6 +1,6 @@
-use pyo3::prelude::*;
-use pyo3::exceptions::PyValueError;
 use ::centaur_technical_indicators::candle_indicators as ci;
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
 
 /// Candle indicators are technical indicators designed for use with candlestick price charts.
 ///
@@ -93,7 +93,8 @@ fn single_moving_constant_envelopes(
         &prices,
         crate::PyConstantModelType::from_string(constant_model_type)?.into(),
         difference,
-    ).map_err(|e| PyValueError::new_err(e.to_string()))
+    )
+    .map_err(|e| PyValueError::new_err(e.to_string()))
 }
 
 /// Calculates the Moving Constant Envelopes
@@ -121,7 +122,8 @@ fn bulk_moving_constant_envelopes(
         crate::PyConstantModelType::from_string(constant_model_type)?.into(),
         difference,
         period,
-    ).map_err(|e| PyValueError::new_err(e.to_string()))
+    )
+    .map_err(|e| PyValueError::new_err(e.to_string()))
 }
 
 // McGinley dynamic envelopes
@@ -143,11 +145,8 @@ fn single_mcginley_dynamic_envelopes(
     difference: f64,
     previous_mcginley_dynamic: f64,
 ) -> PyResult<(f64, f64, f64)> {
-    ci::single::mcginley_dynamic_envelopes(
-        &prices,
-        difference,
-        previous_mcginley_dynamic,
-    ).map_err(|e| PyValueError::new_err(e.to_string()))
+    ci::single::mcginley_dynamic_envelopes(&prices, difference, previous_mcginley_dynamic)
+        .map_err(|e| PyValueError::new_err(e.to_string()))
 }
 
 /// Calculates the McGinley dynamic envelopes
@@ -169,12 +168,8 @@ fn bulk_mcginley_dynamic_envelopes(
     previous_mcginley_dynamic: f64,
     period: usize,
 ) -> PyResult<Vec<(f64, f64, f64)>> {
-    ci::bulk::mcginley_dynamic_envelopes(
-        &prices,
-        difference,
-        previous_mcginley_dynamic,
-        period,
-    ).map_err(|e| PyValueError::new_err(e.to_string()))
+    ci::bulk::mcginley_dynamic_envelopes(&prices, difference, previous_mcginley_dynamic, period)
+        .map_err(|e| PyValueError::new_err(e.to_string()))
 }
 
 // Moving Constant bands
@@ -205,7 +200,8 @@ fn single_moving_constant_bands(
         crate::PyConstantModelType::from_string(constant_model_type)?.into(),
         crate::PyDeviationModel::from_string(deviation_model)?.into(),
         deviation_multiplier,
-    ).map_err(|e| PyValueError::new_err(e.to_string()))
+    )
+    .map_err(|e| PyValueError::new_err(e.to_string()))
 }
 
 /// Calculates moving constant bands
@@ -237,7 +233,8 @@ fn bulk_moving_constant_bands(
         crate::PyDeviationModel::from_string(deviation_model)?.into(),
         deviation_multiplier,
         period,
-    ).map_err(|e| PyValueError::new_err(e.to_string()))
+    )
+    .map_err(|e| PyValueError::new_err(e.to_string()))
 }
 
 // McGinley dynamic bands
@@ -267,7 +264,8 @@ fn single_mcginley_dynamic_bands(
         crate::PyDeviationModel::from_string(deviation_model)?.into(),
         deviation_multiplier,
         previous_mcginley_dynamic,
-    ).map_err(|e| PyValueError::new_err(e.to_string()))
+    )
+    .map_err(|e| PyValueError::new_err(e.to_string()))
 }
 
 /// Calculates McGinley dynamic bands
@@ -298,7 +296,8 @@ fn bulk_mcginley_dynamic_bands(
         deviation_multiplier,
         previous_mcginley_dynamic,
         period,
-    ).map_err(|e| PyValueError::new_err(e.to_string()))
+    )
+    .map_err(|e| PyValueError::new_err(e.to_string()))
 }
 
 // Ichimoku Cloud
@@ -334,7 +333,8 @@ fn single_ichimoku_cloud(
         conversion_period,
         base_period,
         span_b_period,
-    ).map_err(|e| PyValueError::new_err(e.to_string()))
+    )
+    .map_err(|e| PyValueError::new_err(e.to_string()))
 }
 
 /// Calculates the Ichimoku Cloud
@@ -368,7 +368,8 @@ fn bulk_ichimoku_cloud(
         conversion_period,
         base_period,
         span_b_period,
-    ).map_err(|e| PyValueError::new_err(e.to_string()))
+    )
+    .map_err(|e| PyValueError::new_err(e.to_string()))
 }
 
 // Donchian Channels
@@ -405,7 +406,8 @@ fn bulk_donchian_channels(
     low: Vec<f64>,
     period: usize,
 ) -> PyResult<Vec<(f64, f64, f64)>> {
-    ci::bulk::donchian_channels(&high, &low, period).map_err(|e| PyValueError::new_err(e.to_string()))
+    ci::bulk::donchian_channels(&high, &low, period)
+        .map_err(|e| PyValueError::new_err(e.to_string()))
 }
 
 // Keltner Channels
@@ -444,7 +446,8 @@ fn single_keltner_channel(
         crate::PyConstantModelType::from_string(constant_model_type)?.into(),
         crate::PyConstantModelType::from_string(atr_constant_model_type)?.into(),
         multiplier,
-    ).map_err(|e| PyValueError::new_err(e.to_string()))
+    )
+    .map_err(|e| PyValueError::new_err(e.to_string()))
 }
 
 /// Calculates the Keltner Channel over a given period
@@ -484,7 +487,8 @@ fn bulk_keltner_channel(
         crate::PyConstantModelType::from_string(atr_constant_model_type)?.into(),
         multiplier,
         period,
-    ).map_err(|e| PyValueError::new_err(e.to_string()))
+    )
+    .map_err(|e| PyValueError::new_err(e.to_string()))
 }
 
 /// Calculates the Super Trend indicator
@@ -515,7 +519,8 @@ fn single_supertrend(
         &close,
         crate::PyConstantModelType::from_string(constant_model_type)?.into(),
         multiplier,
-    ).map_err(|e| PyValueError::new_err(e.to_string()))
+    )
+    .map_err(|e| PyValueError::new_err(e.to_string()))
 }
 
 /// Calculates the Super Trend indicator
@@ -549,5 +554,6 @@ fn bulk_supertrend(
         crate::PyConstantModelType::from_string(constant_model_type)?.into(),
         multiplier,
         period,
-    ).map_err(|e| PyValueError::new_err(e.to_string()))
+    )
+    .map_err(|e| PyValueError::new_err(e.to_string()))
 }

--- a/src/chart_trends.rs
+++ b/src/chart_trends.rs
@@ -1,6 +1,6 @@
-use pyo3::prelude::*;
-use pyo3::exceptions::PyValueError;
 use ::centaur_technical_indicators::chart_trends as ct;
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
 
 /// The `chart_trends` module provides utilities for detecting, analyzing, and breaking down trends in price charts.
 ///
@@ -33,7 +33,8 @@ pub fn chart_trends(m: &Bound<'_, PyModule>) -> PyResult<()> {
 ///     List of tuples containing (peak value, peak index)
 #[pyfunction]
 fn peaks(prices: Vec<f64>, period: usize, closest_neighbor: usize) -> PyResult<Vec<(f64, usize)>> {
-    Ok(ct::peaks(&prices, period, closest_neighbor).map_err(|e| PyValueError::new_err(e.to_string()))?)
+    Ok(ct::peaks(&prices, period, closest_neighbor)
+        .map_err(|e| PyValueError::new_err(e.to_string()))?)
 }
 
 /// Calculates all valleys for a given period
@@ -51,7 +52,8 @@ fn valleys(
     period: usize,
     closest_neighbor: usize,
 ) -> PyResult<Vec<(f64, usize)>> {
-    Ok(ct::valleys(&prices, period, closest_neighbor).map_err(|e| PyValueError::new_err(e.to_string()))?)
+    Ok(ct::valleys(&prices, period, closest_neighbor)
+        .map_err(|e| PyValueError::new_err(e.to_string()))?)
 }
 
 /// Returns the slope and intercept of the trend line fitted to peaks
@@ -134,5 +136,6 @@ fn break_down_trends(
             hard_durbin_watson_min,
             hard_durbin_watson_max,
         },
-    ).map_err(|e| PyValueError::new_err(e.to_string()))
+    )
+    .map_err(|e| PyValueError::new_err(e.to_string()))
 }

--- a/src/correlation_indicators.rs
+++ b/src/correlation_indicators.rs
@@ -1,6 +1,6 @@
-use pyo3::prelude::*;
-use pyo3::exceptions::PyValueError;
 use ::centaur_technical_indicators::correlation_indicators as ci;
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
 
 /// The `correlation_indicators` module provides functions to measure the co-movement
 /// and statistical relationship between two different price series or assets.
@@ -65,7 +65,8 @@ fn single_correlate_asset_prices(
         &prices_asset_b,
         crate::PyConstantModelType::from_string(constant_model_type)?.into(),
         crate::PyDeviationModel::from_string(deviation_model)?.into(),
-    ).map_err(|e| PyValueError::new_err(e.to_string()))
+    )
+    .map_err(|e| PyValueError::new_err(e.to_string()))
 }
 
 /// Calculates the correlation between two asset prices over a period.
@@ -97,5 +98,6 @@ fn bulk_correlate_asset_prices(
         crate::PyConstantModelType::from_string(constant_model_type)?.into(),
         crate::PyDeviationModel::from_string(deviation_model)?.into(),
         period,
-    ).map_err(|e| PyValueError::new_err(e.to_string()))
+    )
+    .map_err(|e| PyValueError::new_err(e.to_string()))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,9 @@
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 
-use ::centaur_technical_indicators::{ConstantModelType, DeviationModel, MovingAverageType, Position};
+use ::centaur_technical_indicators::{
+    ConstantModelType, DeviationModel, MovingAverageType, Position,
+};
 
 pub mod candle_indicators;
 pub mod chart_trends;

--- a/src/momentum_indicators.rs
+++ b/src/momentum_indicators.rs
@@ -1,6 +1,6 @@
-use pyo3::prelude::*;
-use pyo3::exceptions::PyValueError;
 use ::centaur_technical_indicators::momentum_indicators as mi;
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
 
 /// The `momentum_indicators` module provides functions to measure the speed, strength, and direction of price movements in time series data.
 ///
@@ -125,7 +125,8 @@ fn single_relative_strength_index(prices: Vec<f64>, constant_model_type: &str) -
     mi::single::relative_strength_index(
         &prices,
         crate::PyConstantModelType::from_string(constant_model_type)?.into(),
-    ).map_err(|e| PyValueError::new_err(e.to_string()))
+    )
+    .map_err(|e| PyValueError::new_err(e.to_string()))
 }
 
 /// Calculates the Relative strength index (RSI)
@@ -150,7 +151,8 @@ fn bulk_relative_strength_index(
         &prices,
         crate::PyConstantModelType::from_string(constant_model_type)?.into(),
         period,
-    ).map_err(|e| PyValueError::new_err(e.to_string()))
+    )
+    .map_err(|e| PyValueError::new_err(e.to_string()))
 }
 
 // Stochastic Oscillator
@@ -166,7 +168,8 @@ fn bulk_relative_strength_index(
 /// See: <https://tech.centaurresearchtechnologies.com/indicators/momentum-indicators/stochastic-oscillator/>
 #[pyfunction(name = "stochastic_oscillator")]
 fn single_stochastic_oscillator(prices: Vec<f64>) -> PyResult<f64> {
-    Ok(mi::single::stochastic_oscillator(&prices).map_err(|e| PyValueError::new_err(e.to_string()))?)
+    Ok(mi::single::stochastic_oscillator(&prices)
+        .map_err(|e| PyValueError::new_err(e.to_string()))?)
 }
 
 /// Calculates the stochastic oscillator
@@ -181,7 +184,8 @@ fn single_stochastic_oscillator(prices: Vec<f64>) -> PyResult<f64> {
 /// See: <https://tech.centaurresearchtechnologies.com/indicators/momentum-indicators/stochastic-oscillator/>
 #[pyfunction(name = "stochastic_oscillator")]
 fn bulk_stochastic_oscillator(prices: Vec<f64>, period: usize) -> PyResult<Vec<f64>> {
-    Ok(mi::bulk::stochastic_oscillator(&prices, period).map_err(|e| PyValueError::new_err(e.to_string()))?)
+    Ok(mi::bulk::stochastic_oscillator(&prices, period)
+        .map_err(|e| PyValueError::new_err(e.to_string()))?)
 }
 
 // Slow Stochastic
@@ -201,7 +205,8 @@ fn single_slow_stochastic(stochastics: Vec<f64>, constant_model_type: &str) -> P
     Ok(mi::single::slow_stochastic(
         &stochastics,
         crate::PyConstantModelType::from_string(constant_model_type)?.into(),
-    ).map_err(|e| PyValueError::new_err(e.to_string()))?)
+    )
+    .map_err(|e| PyValueError::new_err(e.to_string()))?)
 }
 
 /// Calculates the slow stochastic
@@ -225,7 +230,8 @@ fn bulk_slow_stochastic(
         &stochastics,
         crate::PyConstantModelType::from_string(constant_model_type)?.into(),
         period,
-    ).map_err(|e| PyValueError::new_err(e.to_string()))?)
+    )
+    .map_err(|e| PyValueError::new_err(e.to_string()))?)
 }
 
 // Slowest Stochastic
@@ -248,7 +254,8 @@ fn single_slowest_stochastic(
     Ok(mi::single::slowest_stochastic(
         &slow_stochastics,
         crate::PyConstantModelType::from_string(constant_model_type)?.into(),
-    ).map_err(|e| PyValueError::new_err(e.to_string()))?)
+    )
+    .map_err(|e| PyValueError::new_err(e.to_string()))?)
 }
 
 /// Calculates the slowest Stochastic
@@ -272,7 +279,8 @@ fn bulk_slowest_stochastic(
         &slow_stochastics,
         crate::PyConstantModelType::from_string(constant_model_type)?.into(),
         period,
-    ).map_err(|e| PyValueError::new_err(e.to_string()))?)
+    )
+    .map_err(|e| PyValueError::new_err(e.to_string()))?)
 }
 
 // Wiiliams %R
@@ -290,7 +298,8 @@ fn bulk_slowest_stochastic(
 /// See: <https://tech.centaurresearchtechnologies.com/indicators/momentum-indicators/williams-percent-r/>
 #[pyfunction(name = "williams_percent_r")]
 fn single_williams_percent_r(high: Vec<f64>, low: Vec<f64>, close: f64) -> PyResult<f64> {
-    Ok(mi::single::williams_percent_r(&high, &low, close).map_err(|e| PyValueError::new_err(e.to_string()))?)
+    Ok(mi::single::williams_percent_r(&high, &low, close)
+        .map_err(|e| PyValueError::new_err(e.to_string()))?)
 }
 
 /// Calculates the Williams %R
@@ -312,7 +321,8 @@ fn bulk_williams_percent_r(
     close: Vec<f64>,
     period: usize,
 ) -> PyResult<Vec<f64>> {
-    Ok(mi::bulk::williams_percent_r(&high, &low, &close, period).map_err(|e| PyValueError::new_err(e.to_string()))?)
+    Ok(mi::bulk::williams_percent_r(&high, &low, &close, period)
+        .map_err(|e| PyValueError::new_err(e.to_string()))?)
 }
 
 // Money Flow Index
@@ -329,7 +339,8 @@ fn bulk_williams_percent_r(
 /// See: <https://tech.centaurresearchtechnologies.com/indicators/momentum-indicators/money-flow-index/>
 #[pyfunction(name = "money_flow_index")]
 fn single_money_flow_index(prices: Vec<f64>, volume: Vec<f64>) -> PyResult<f64> {
-    Ok(mi::single::money_flow_index(&prices, &volume).map_err(|e| PyValueError::new_err(e.to_string()))?)
+    Ok(mi::single::money_flow_index(&prices, &volume)
+        .map_err(|e| PyValueError::new_err(e.to_string()))?)
 }
 
 /// Calculates the Money Flow Index (MFI)
@@ -345,7 +356,8 @@ fn single_money_flow_index(prices: Vec<f64>, volume: Vec<f64>) -> PyResult<f64> 
 /// See: <https://tech.centaurresearchtechnologies.com/indicators/momentum-indicators/money-flow-index/>
 #[pyfunction(name = "money_flow_index")]
 fn bulk_money_flow_index(prices: Vec<f64>, volume: Vec<f64>, period: usize) -> PyResult<Vec<f64>> {
-    Ok(mi::bulk::money_flow_index(&prices, &volume, period).map_err(|e| PyValueError::new_err(e.to_string()))?)
+    Ok(mi::bulk::money_flow_index(&prices, &volume, period)
+        .map_err(|e| PyValueError::new_err(e.to_string()))?)
 }
 
 // Rate of Change
@@ -362,7 +374,8 @@ fn bulk_money_flow_index(prices: Vec<f64>, volume: Vec<f64>, period: usize) -> P
 /// See: <https://tech.centaurresearchtechnologies.com/indicators/momentum-indicators/rate-of-change/>
 #[pyfunction(name = "rate_of_change")]
 fn single_rate_of_change(current_price: f64, previous_price: f64) -> PyResult<f64> {
-    Ok(mi::single::rate_of_change(current_price, previous_price).map_err(|e| PyValueError::new_err(e.to_string()))?)
+    Ok(mi::single::rate_of_change(current_price, previous_price)
+        .map_err(|e| PyValueError::new_err(e.to_string()))?)
 }
 
 /// Calculates the Rate of Change (RoC)
@@ -405,7 +418,8 @@ fn single_on_balance_volume(
         previous_price,
         current_volume,
         previous_on_balance_volume,
-    ).map_err(|e| PyValueError::new_err(e.to_string()))?)
+    )
+    .map_err(|e| PyValueError::new_err(e.to_string()))?)
 }
 
 /// Calculates the On Balance Volume (OBV)
@@ -425,11 +439,10 @@ fn bulk_on_balance_volume(
     volume: Vec<f64>,
     previous_on_balance_volume: f64,
 ) -> PyResult<Vec<f64>> {
-    Ok(mi::bulk::on_balance_volume(
-        &prices,
-        &volume,
-        previous_on_balance_volume,
-    ).map_err(|e| PyValueError::new_err(e.to_string()))?)
+    Ok(
+        mi::bulk::on_balance_volume(&prices, &volume, previous_on_balance_volume)
+            .map_err(|e| PyValueError::new_err(e.to_string()))?,
+    )
 }
 
 // Commodity Channel Index
@@ -460,7 +473,8 @@ fn single_commodity_channel_index(
         crate::PyConstantModelType::from_string(constant_model_type)?.into(),
         crate::PyDeviationModel::from_string(deviation_model)?.into(),
         constant_multiplier,
-    ).map_err(|e| PyValueError::new_err(e.to_string()))?)
+    )
+    .map_err(|e| PyValueError::new_err(e.to_string()))?)
 }
 
 /// Calculates the Commodity Channel Index (CCI)
@@ -492,7 +506,8 @@ fn bulk_commodity_channel_index(
         crate::PyDeviationModel::from_string(deviation_model)?.into(),
         constant_multiplier,
         period,
-    ).map_err(|e| PyValueError::new_err(e.to_string()))?)
+    )
+    .map_err(|e| PyValueError::new_err(e.to_string()))?)
 }
 
 // McGinley Dynamic Commodity Channel Index
@@ -522,7 +537,8 @@ fn single_mcginley_dynamic_commodity_channel_index(
         previous_mcginley_dynamic,
         crate::PyDeviationModel::from_string(deviation_model)?.into(),
         constant_multiplier,
-    ).map_err(|e| PyValueError::new_err(e.to_string()))?)
+    )
+    .map_err(|e| PyValueError::new_err(e.to_string()))?)
 }
 
 /// Calculates the McGinley Dynamic Commodity Channel Index (CCI)
@@ -553,7 +569,8 @@ fn bulk_mcginley_dynamic_commodity_channel_index(
         crate::PyDeviationModel::from_string(deviation_model)?.into(),
         constant_multiplier,
         period,
-    ).map_err(|e| PyValueError::new_err(e.to_string()))?)
+    )
+    .map_err(|e| PyValueError::new_err(e.to_string()))?)
 }
 
 // MACD
@@ -584,7 +601,8 @@ fn single_macd_line(
         short_period,
         crate::PyConstantModelType::from_string(short_period_model)?.into(),
         crate::PyConstantModelType::from_string(long_period_model)?.into(),
-    ).map_err(|e| PyValueError::new_err(e.to_string()))?)
+    )
+    .map_err(|e| PyValueError::new_err(e.to_string()))?)
 }
 
 /// Calculates the Moving Average Convergence Divergence (MACD) line
@@ -616,7 +634,8 @@ fn bulk_macd_line(
         crate::PyConstantModelType::from_string(short_period_model)?.into(),
         long_period,
         crate::PyConstantModelType::from_string(long_period_model)?.into(),
-    ).map_err(|e| PyValueError::new_err(e.to_string()))?)
+    )
+    .map_err(|e| PyValueError::new_err(e.to_string()))?)
 }
 
 // MACD Signal line
@@ -636,7 +655,8 @@ fn single_signal_line(macds: Vec<f64>, constant_model_type: &str) -> PyResult<f6
     Ok(mi::single::signal_line(
         &macds,
         crate::PyConstantModelType::from_string(constant_model_type)?.into(),
-    ).map_err(|e| PyValueError::new_err(e.to_string()))?)
+    )
+    .map_err(|e| PyValueError::new_err(e.to_string()))?)
 }
 
 /// Calculates the MACD signal line divergence.
@@ -660,7 +680,8 @@ fn bulk_signal_line(
         &macds,
         crate::PyConstantModelType::from_string(constant_model_type)?.into(),
         period,
-    ).map_err(|e| PyValueError::new_err(e.to_string()))?)
+    )
+    .map_err(|e| PyValueError::new_err(e.to_string()))?)
 }
 
 // McGinley Dynamic MACD
@@ -690,7 +711,8 @@ fn single_mcginley_dynamic_macd_line(
         short_period,
         previous_short_mcginley,
         previous_long_mcginley,
-    ).map_err(|e| PyValueError::new_err(e.to_string()))?)
+    )
+    .map_err(|e| PyValueError::new_err(e.to_string()))?)
 }
 
 /// Calculates the McGinley dynamic MACD line
@@ -721,7 +743,8 @@ fn bulk_mcginley_dynamic_macd_line(
         previous_short_mcginley,
         long_period,
         previous_long_mcginley,
-    ).map_err(|e| PyValueError::new_err(e.to_string()))?)
+    )
+    .map_err(|e| PyValueError::new_err(e.to_string()))?)
 }
 
 // Chaikin Oscillator
@@ -764,7 +787,8 @@ fn single_chaikin_oscillator(
         previous_accumulation_distribution,
         crate::PyConstantModelType::from_string(short_period_model)?.into(),
         crate::PyConstantModelType::from_string(long_period_model)?.into(),
-    ).map_err(|e| PyValueError::new_err(e.to_string()))?)
+    )
+    .map_err(|e| PyValueError::new_err(e.to_string()))?)
 }
 
 /// Calculates the  Chaikin Oscillator (CO)
@@ -808,7 +832,8 @@ fn bulk_chaikin_oscillator(
         previous_accumulation_distribution,
         crate::PyConstantModelType::from_string(short_period_model)?.into(),
         crate::PyConstantModelType::from_string(long_period_model)?.into(),
-    ).map_err(|e| PyValueError::new_err(e.to_string()))?)
+    )
+    .map_err(|e| PyValueError::new_err(e.to_string()))?)
 }
 
 // Percentage Price Oscillator
@@ -835,7 +860,8 @@ fn single_percentage_price_oscillator(
         &prices,
         short_period,
         crate::PyConstantModelType::from_string(constant_model_type)?.into(),
-    ).map_err(|e| PyValueError::new_err(e.to_string()))?)
+    )
+    .map_err(|e| PyValueError::new_err(e.to_string()))?)
 }
 
 /// Calculates the Percentage Price Oscillator (PPO)
@@ -863,7 +889,8 @@ fn bulk_percentage_price_oscillator(
         short_period,
         long_period,
         crate::PyConstantModelType::from_string(constant_model_type)?.into(),
-    ).map_err(|e| PyValueError::new_err(e.to_string()))?)
+    )
+    .map_err(|e| PyValueError::new_err(e.to_string()))?)
 }
 
 // Chande Momentum Oscillator
@@ -879,7 +906,8 @@ fn bulk_percentage_price_oscillator(
 /// See: <https://tech.centaurresearchtechnologies.com/indicators/momentum-indicators/chande-momentum-oscillator/>
 #[pyfunction(name = "chande_momentum_oscillator")]
 fn single_chande_momentum_oscillator(prices: Vec<f64>) -> PyResult<f64> {
-    Ok(mi::single::chande_momentum_oscillator(&prices).map_err(|e| PyValueError::new_err(e.to_string()))?)
+    Ok(mi::single::chande_momentum_oscillator(&prices)
+        .map_err(|e| PyValueError::new_err(e.to_string()))?)
 }
 
 /// Calculates the Chande Momentum Oscillator (CMO)
@@ -894,5 +922,6 @@ fn single_chande_momentum_oscillator(prices: Vec<f64>) -> PyResult<f64> {
 /// See: <https://tech.centaurresearchtechnologies.com/indicators/momentum-indicators/chande-momentum-oscillator/>
 #[pyfunction(name = "chande_momentum_oscillator")]
 fn bulk_chande_momentum_oscillator(prices: Vec<f64>, period: usize) -> PyResult<Vec<f64>> {
-    Ok(mi::bulk::chande_momentum_oscillator(&prices, period).map_err(|e| PyValueError::new_err(e.to_string()))?)
+    Ok(mi::bulk::chande_momentum_oscillator(&prices, period)
+        .map_err(|e| PyValueError::new_err(e.to_string()))?)
 }

--- a/src/moving_average.rs
+++ b/src/moving_average.rs
@@ -1,6 +1,6 @@
-use pyo3::prelude::*;
-use pyo3::exceptions::PyValueError;
 use ::centaur_technical_indicators::moving_average as ma;
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
 
 /// The `moving_average` module provides functions for calculating moving averages, a core component of many technical indicators and trading strategies.
 ///
@@ -47,7 +47,8 @@ fn single_moving_average(prices: Vec<f64>, moving_average_type: &str) -> PyResul
     ma::single::moving_average(
         &prices,
         crate::PyMovingAverageType::from_string(moving_average_type)?.into(),
-    ).map_err(|e| PyValueError::new_err(e.to_string()))
+    )
+    .map_err(|e| PyValueError::new_err(e.to_string()))
 }
 
 /// Calculates the Moving Average over a rolling period
@@ -71,7 +72,8 @@ fn bulk_moving_average(
         &prices,
         crate::PyMovingAverageType::from_string(moving_average_type)?.into(),
         period,
-    ).map_err(|e| PyValueError::new_err(e.to_string()))
+    )
+    .map_err(|e| PyValueError::new_err(e.to_string()))
 }
 
 /// Calculates the McGinley dynamic
@@ -91,11 +93,8 @@ fn single_mcginley_dynamic(
     previous_mcginley_dynamic: f64,
     period: usize,
 ) -> PyResult<f64> {
-    ma::single::mcginley_dynamic(
-        latest_price,
-        previous_mcginley_dynamic,
-        period,
-    ).map_err(|e| PyValueError::new_err(e.to_string()))
+    ma::single::mcginley_dynamic(latest_price, previous_mcginley_dynamic, period)
+        .map_err(|e| PyValueError::new_err(e.to_string()))
 }
 
 /// Calculates the McGinley dynamic
@@ -115,9 +114,6 @@ fn bulk_mcginley_dynamic(
     previous_mcginley_dynamic: f64,
     period: usize,
 ) -> PyResult<Vec<f64>> {
-    ma::bulk::mcginley_dynamic(
-        &prices,
-        previous_mcginley_dynamic,
-        period,
-    ).map_err(|e| PyValueError::new_err(e.to_string()))
+    ma::bulk::mcginley_dynamic(&prices, previous_mcginley_dynamic, period)
+        .map_err(|e| PyValueError::new_err(e.to_string()))
 }

--- a/src/other_indicators.rs
+++ b/src/other_indicators.rs
@@ -1,6 +1,6 @@
-use pyo3::prelude::*;
-use pyo3::exceptions::PyValueError;
 use ::centaur_technical_indicators::other_indicators as oi;
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
 
 /// The `other_indicators` module provides technical analysis tools that do not fit neatly
 /// into the main categories like momentum, trend, or volatility.
@@ -90,7 +90,8 @@ fn single_return_on_investment(
 /// See: <https://tech.centaurresearchtechnologies.com/indicators/other-indicators/return-on-investment/>
 #[pyfunction(name = "return_on_investment")]
 fn bulk_return_on_investment(prices: Vec<f64>, investment: f64) -> PyResult<Vec<(f64, f64)>> {
-    Ok(oi::bulk::return_on_investment(&prices, investment).map_err(|e| PyValueError::new_err(e.to_string()))?)
+    Ok(oi::bulk::return_on_investment(&prices, investment)
+        .map_err(|e| PyValueError::new_err(e.to_string()))?)
 }
 
 // True Range
@@ -124,7 +125,8 @@ fn single_true_range(close: f64, high: f64, low: f64) -> PyResult<f64> {
 /// See: <https://tech.centaurresearchtechnologies.com/indicators/other-indicators/true-range/>
 #[pyfunction(name = "true_range")]
 fn bulk_true_range(close: Vec<f64>, high: Vec<f64>, low: Vec<f64>) -> PyResult<Vec<f64>> {
-    Ok(oi::bulk::true_range(&close, &high, &low).map_err(|e| PyValueError::new_err(e.to_string()))?)
+    Ok(oi::bulk::true_range(&close, &high, &low)
+        .map_err(|e| PyValueError::new_err(e.to_string()))?)
 }
 
 // Average True Range
@@ -154,7 +156,8 @@ fn single_average_true_range(
         &high,
         &low,
         crate::PyConstantModelType::from_string(constant_model_type)?.into(),
-    ).map_err(|e| PyValueError::new_err(e.to_string()))
+    )
+    .map_err(|e| PyValueError::new_err(e.to_string()))
 }
 
 /// Calculates the Average True Range (ATR) over a period
@@ -185,7 +188,8 @@ fn bulk_average_true_range(
         &low,
         crate::PyConstantModelType::from_string(constant_model_type)?.into(),
         period,
-    ).map_err(|e| PyValueError::new_err(e.to_string()))
+    )
+    .map_err(|e| PyValueError::new_err(e.to_string()))
 }
 
 // Internal Bar Strength
@@ -223,7 +227,8 @@ fn bulk_internal_bar_strength(
     low: Vec<f64>,
     close: Vec<f64>,
 ) -> PyResult<Vec<f64>> {
-    Ok(oi::bulk::internal_bar_strength(&high, &low, &close).map_err(|e| PyValueError::new_err(e.to_string()))?)
+    Ok(oi::bulk::internal_bar_strength(&high, &low, &close)
+        .map_err(|e| PyValueError::new_err(e.to_string()))?)
 }
 
 // Positivity Indicator
@@ -253,5 +258,6 @@ fn bulk_positivity_indicator(
         &previous_close,
         signal_period,
         crate::PyConstantModelType::from_string(constant_model_type)?.into(),
-    ).map_err(|e| PyValueError::new_err(e.to_string()))
+    )
+    .map_err(|e| PyValueError::new_err(e.to_string()))
 }

--- a/src/strength_indicators.rs
+++ b/src/strength_indicators.rs
@@ -1,6 +1,6 @@
-use pyo3::prelude::*;
-use pyo3::exceptions::PyValueError;
 use ::centaur_technical_indicators::strength_indicators as si;
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
 
 /// The `strength_indicators` module provides functions to assess the strength and conviction of
 /// price movements and trends using volume and price-based calculations.
@@ -110,7 +110,8 @@ fn bulk_accumulation_distribution(
         &close,
         &volume,
         previous_accumulation_distribution,
-    ).map_err(|e| PyValueError::new_err(e.to_string()))
+    )
+    .map_err(|e| PyValueError::new_err(e.to_string()))
 }
 
 // Volume Index
@@ -156,11 +157,8 @@ fn bulk_positive_volume_index(
     volume: Vec<f64>,
     previous_volume_index: f64,
 ) -> PyResult<Vec<f64>> {
-    si::bulk::positive_volume_index(
-        &close,
-        &volume,
-        previous_volume_index,
-    ).map_err(|e| PyValueError::new_err(e.to_string()))
+    si::bulk::positive_volume_index(&close, &volume, previous_volume_index)
+        .map_err(|e| PyValueError::new_err(e.to_string()))
 }
 
 /// Calculates the Negative Volume Index (NVI)
@@ -180,11 +178,8 @@ fn bulk_negative_volume_index(
     volume: Vec<f64>,
     previous_volume_index: f64,
 ) -> PyResult<Vec<f64>> {
-    si::bulk::negative_volume_index(
-        &close,
-        &volume,
-        previous_volume_index,
-    ).map_err(|e| PyValueError::new_err(e.to_string()))
+    si::bulk::negative_volume_index(&close, &volume, previous_volume_index)
+        .map_err(|e| PyValueError::new_err(e.to_string()))
 }
 
 // Relative Vigor Index
@@ -217,7 +212,8 @@ fn single_relative_vigor_index(
         &low,
         &close,
         crate::PyConstantModelType::from_string(constant_model_type)?.into(),
-    ).map_err(|e| PyValueError::new_err(e.to_string()))
+    )
+    .map_err(|e| PyValueError::new_err(e.to_string()))
 }
 
 /// Calculates the Relative Vigor Index (RVI)
@@ -251,5 +247,6 @@ fn bulk_relative_vigor_index(
         &close,
         crate::PyConstantModelType::from_string(constant_model_type)?.into(),
         period,
-    ).map_err(|e| PyValueError::new_err(e.to_string()))
+    )
+    .map_err(|e| PyValueError::new_err(e.to_string()))
 }

--- a/src/trend_indicators.rs
+++ b/src/trend_indicators.rs
@@ -1,6 +1,6 @@
-use pyo3::prelude::*;
-use pyo3::exceptions::PyValueError;
 use ::centaur_technical_indicators::trend_indicators as ti;
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
 
 /// The `trend_indicators` module provides functions to analyze and quantify price trends in time series data.
 ///
@@ -158,7 +158,8 @@ fn single_aroon_oscillator(aroon_up: f64, aroon_down: f64) -> PyResult<f64> {
 /// See: <https://tech.centaurresearchtechnologies.com/indicators/trend-indicators/aroon-indicator/>
 #[pyfunction(name = "aroon_oscillator")]
 fn bulk_aroon_oscillator(aroon_up: Vec<f64>, aroon_down: Vec<f64>) -> PyResult<Vec<f64>> {
-    Ok(ti::bulk::aroon_oscillator(&aroon_up, &aroon_down).map_err(|e| PyValueError::new_err(e.to_string()))?)
+    Ok(ti::bulk::aroon_oscillator(&aroon_up, &aroon_down)
+        .map_err(|e| PyValueError::new_err(e.to_string()))?)
 }
 
 // Aroon Indidcator
@@ -195,7 +196,8 @@ fn bulk_aroon_indicator(
     lows: Vec<f64>,
     period: usize,
 ) -> PyResult<Vec<(f64, f64, f64)>> {
-    Ok(ti::bulk::aroon_indicator(&highs, &lows, period).map_err(|e| PyValueError::new_err(e.to_string()))?)
+    Ok(ti::bulk::aroon_indicator(&highs, &lows, period)
+        .map_err(|e| PyValueError::new_err(e.to_string()))?)
 }
 
 // Parabolic Time Price System
@@ -287,7 +289,8 @@ fn bulk_parabolic_time_price_system(
         af_max,
         crate::PyPosition::from_string(position)?.into(),
         previous_sar,
-    ).map_err(|e| PyValueError::new_err(e.to_string()))
+    )
+    .map_err(|e| PyValueError::new_err(e.to_string()))
 }
 
 // Directional Movement System
@@ -320,7 +323,8 @@ fn bulk_directional_movement_system(
         &close,
         period,
         crate::PyConstantModelType::from_string(constant_model_type)?.into(),
-    ).map_err(|e| PyValueError::new_err(e.to_string()))
+    )
+    .map_err(|e| PyValueError::new_err(e.to_string()))
 }
 
 // Volume Price Trend
@@ -365,11 +369,8 @@ fn bulk_volume_price_trend(
     volumes: Vec<f64>,
     previous_vpt: f64,
 ) -> PyResult<Vec<f64>> {
-    ti::bulk::volume_price_trend(
-        &prices,
-        &volumes,
-        previous_vpt,
-    ).map_err(|e| PyValueError::new_err(e.to_string()))
+    ti::bulk::volume_price_trend(&prices, &volumes, previous_vpt)
+        .map_err(|e| PyValueError::new_err(e.to_string()))
 }
 
 // True Strength Index
@@ -400,7 +401,8 @@ fn single_true_strength_index(
         crate::PyConstantModelType::from_string(first_constant_model)?.into(),
         first_period,
         crate::PyConstantModelType::from_string(second_constant_model)?.into(),
-    ).map_err(|e| PyValueError::new_err(e.to_string()))
+    )
+    .map_err(|e| PyValueError::new_err(e.to_string()))
 }
 
 /// Calculates the True Strength Index (TSI) over a period
@@ -432,5 +434,6 @@ fn bulk_true_strength_index(
         first_period,
         crate::PyConstantModelType::from_string(second_constant_model)?.into(),
         second_period,
-    ).map_err(|e| PyValueError::new_err(e.to_string()))
+    )
+    .map_err(|e| PyValueError::new_err(e.to_string()))
 }

--- a/src/volatility_indicators.rs
+++ b/src/volatility_indicators.rs
@@ -1,6 +1,6 @@
-use pyo3::prelude::*;
-use pyo3::exceptions::PyValueError;
 use ::centaur_technical_indicators::volatility_indicators as vi;
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
 
 /// The `volatility_indicators` module provides functions for measuring the volatility of an asset—how much and how quickly prices move over time.
 ///
@@ -90,5 +90,6 @@ fn bulk_volatility_system(
         period,
         constant_multiplier,
         crate::PyConstantModelType::from_string(constant_model_type)?.into(),
-    ).map_err(|e| PyValueError::new_err(e.to_string()))
+    )
+    .map_err(|e| PyValueError::new_err(e.to_string()))
 }


### PR DESCRIPTION
## Summary
Repo-wide `cargo fmt --all` baseline; **formatting only**. No behavior or logic changes. Establishes a clean formatting baseline so `cargo fmt --check` can serve as a real pre-PR / CI gate for the rest of the release.

The diff is exclusively `use`-import reordering and rustfmt's method-chain / argument reflow (closing parens onto their own line, trailing-comma adjustments). `git diff -w --ignore-all-space` shows no token-level changes — no renamed identifiers, no changed string literals or numbers.

## Scope
- Touched: all 10 `src/*.rs` files (171 insertions, 126 deletions).
- Intentionally not touched: no `CHANGELOG.md`, `Cargo.toml`, CI files, docs, or dependency/version changes.

## Compatibility
None — no API or behavior change.

## Validation
- Toolchain: `rustc 1.94.0 (4a4ef493e 2026-03-02)`, `rustfmt 1.8.0-stable (4a4ef493e3 2026-03-02)`. (A later CI step must use a matching rustfmt or it could re-introduce drift.)
- `cargo fmt --all -- --check` → exit **0** (was exit 1 / ~84 hunks before).
- `maturin develop` → clean build.
- `python -m pytest` → **100 passed** (unchanged from baseline).

## Changelog
**None** — formatting-only, not user-facing. This change is the explicit exception to the "every change gets a paired CHANGELOG.md entry" rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)