### PR TITLE
chore: bump centaur_technical_indicators dependency to 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Changed
+- Updated `centaur_technical_indicators` Rust crate dependency from `1.2.2` to `1.3.0`.
+
 ## [1.2.2] - 2026-04-04
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,15 +12,15 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 name = "centaur_technical_indicators"
 version = "1.2.2"
 dependencies = [
- "centaur_technical_indicators 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "centaur_technical_indicators 1.3.0",
  "pyo3",
 ]
 
 [[package]]
 name = "centaur_technical_indicators"
-version = "1.2.2"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24ae4cb5750fab3c9d2ae9be158158df08bb4b052c6e5c398885be57e0590be9"
+checksum = "41f1d42ebb4f20df394539be4afd1a21f69a6f18c7ab9ae3a8eaeac7929e1bfb"
 
 [[package]]
 name = "heck"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,4 @@ crate-type = ["cdylib"]
 
 [dependencies]
 pyo3 = "0.25.0"
-centaur_technical_indicators = "1.2.2"
+centaur_technical_indicators = "1.3.0"


### PR DESCRIPTION
## Summary

Bump the upstream `centaur_technical_indicators` Rust crate dependency from `1.2.2` to `1.3.0` in `Cargo.toml` (with `Cargo.lock` regenerated). The local `[package] version` is intentionally left at `1.2.2` (release cut is a later step).

## Compatibility

None — additive dependency bump. Every upstream signature this binding calls is byte-identical between 1.2.2 and 1.3.0; the only upstream diffs are internal NaN-hardening and an added `#[allow(unreachable_patterns)]`. No Python API surface or indicator semantics change.

## Validation

- `maturin develop` — clean build against 1.3.0.
- `python -m pytest` — **100 passed**.
- `cargo fmt --all -- --check` — clean (no Rust source edited).

## Changelog

Under `## [Unreleased]`:

```
### Changed
- Updated `centaur_technical_indicators` Rust crate dependency from `1.2.2` to `1.3.0`.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)