### PR TITLE
chore: fix Documentation URL and expand Python classifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+- Incorrect `Documentation` URL in package metadata (pointed at the GitHub wiki).
+
+### Changed
+- Expanded PyPI classifiers to declare Python 3.10–3.14.
+
 ## [1.2.2] - 2026-04-04
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,12 +23,17 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Rust",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 dynamic = ["version"]
 
 [project.urls]
 "Homepage" = "https://github.com/chironmind/CentaurTechnicalIndicators-Python"
-"Documentation" = "https://github.com/chironmind/CentaurTechnicalIndicators-Python/wiki"
+"Documentation" = "https://centaurtechnicalindicators-python.readthedocs.io/en/latest/"
 "Source" = "https://github.com/chironmind/CentaurTechnicalIndicators-Python"
 "Issues" = "https://github.com/chironmind/CentaurTechnicalIndicators-Python/issues"
 


### PR DESCRIPTION
## Summary

Fixes two pieces of `pyproject.toml` metadata drift:

- **Documentation URL** repointed from the GitHub `/wiki` to the ReadTheDocs root used by the README docs badge: `https://centaurtechnicalindicators-python.readthedocs.io/en/latest/`.
- **Classifiers** expanded with per-minor Python entries (`3.10`–`3.14`), keeping the existing generic `Programming Language :: Python :: 3`. These match the test matrix in `.github/workflows/python-package.yml`.

The `description` string, `[tool.maturin]` table, and author/maintainer `email` placeholders are intentionally left untouched (owned by other changes / retained for 1.3.0).

## Compatibility

None. Metadata-only change; no API, behavior, or error-handling impact.

## Validation

- `maturin develop` — built and installed cleanly
- `python -m pytest` — 100 passed
- `cargo fmt --all -- --check` — clean
- `python -c "import centaur_technical_indicators as c; print(c.__all__)"` — nine submodules auto-populated; no change needed

## Changelog

Under `## [Unreleased]`:

\`\`\`
### Fixed
- Incorrect \`Documentation\` URL in package metadata (pointed at the GitHub wiki).

### Changed
- Expanded PyPI classifiers to declare Python 3.10–3.14.
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)