### PR TITLE
ci: add cargo fmt --check to verify job

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,6 +23,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      - name: Check Rust formatting
+        run: cargo fmt --all -- --check
       - uses: actions/setup-python@v6
         with:
           python-version: '3.12'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+- `cargo fmt --check` step to CI (the `verify` job in `CI.yml`).
+
 ## [1.2.2] - 2026-04-04
 
 ### Fixed


### PR DESCRIPTION
## Summary

Adds a `cargo fmt --all -- --check` step to the `verify` job in `CI.yml`, enforcing the repo's stated pre-PR formatting gate in CI. The step runs before the Python test step so a formatting failure surfaces early. Kept native (cargo/shell only) — no third-party GitHub Actions, no clippy (parked, needs maintainer approval). `ubuntu-latest` runners ship Rust + rustfmt, so no toolchain setup was required.

This is the approved CI exception (a planned release step). Only `CI.yml` is touched; `python-package.yml` and all wheel-build/release jobs are untouched.

## Compatibility

None. CI-only change with no impact on the public API, indicator semantics, or published artifacts.

## Validation

- `cargo fmt --all -- --check` — exits clean (no toolchain skew vs. the landed baseline).

## Changelog

Under `## [Unreleased]`:

```
### Added
- `cargo fmt --check` step to CI (the `verify` job in `CI.yml`).
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)