### PR TITLE
docs: document and pin model-type/deviation/MA string aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+- Tests pinning accepted model-type / deviation-model / moving-average-type string aliases.
+- Documentation of the full accepted string-alias set for each regime (incl. the `sma`→Smoothed
+  / `ma`→Simple aliases), with `from_string` error messages reconciled to match.
+
 ## [1.2.2] - 2026-04-04
 
 ### Fixed

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,18 +25,45 @@ pub enum PyConstantModelType {
 }
 
 impl PyConstantModelType {
-    // Add a method to create from string
+    /// Parse a `ConstantModelType` from a string alias (matching is case-insensitive).
+    ///
+    /// Each variant accepts a primary one-word form, a short abbreviation, and a long
+    /// snake_case form. The full accepted set is:
+    ///
+    /// - `simple` | `ma` | `simple_moving_average` → Simple moving average
+    /// - `smoothed` | `sma` | `smoothed_moving_average` → Smoothed moving average
+    /// - `exponential` | `ema` | `exponential_moving_average` → Exponential moving average
+    /// - `median` | `smm` | `simple_moving_median` → Simple moving median
+    /// - `mode` | `simple_moving_mode` → Simple moving mode (no 3-letter abbreviation)
+    ///
+    /// **Watch the abbreviations:** `ma` → **Simple** and `sma` → **Smoothed** (not Simple).
+    ///
+    /// Note these abbreviations and snake_case forms are accepted *here* but **not** by
+    /// [`PyMovingAverageType::from_string`], which takes only `simple`/`smoothed`/`exponential`.
     pub fn from_string(s: &str) -> PyResult<Self> {
         match s.to_lowercase().as_str() {
-            "simple" | "ma" | "simple_moving_average" => Ok(PyConstantModelType::SimpleMovingAverage),
-            "smoothed" | "sma" | "smoothed_moving_average" => Ok(PyConstantModelType::SmoothedMovingAverage),
-            "exponential" | "ema" | "exponential_moving_average" => Ok(PyConstantModelType::ExponentialMovingAverage),
-            "median" | "smm" | "simple_moving_median" => Ok(PyConstantModelType::SimpleMovingMedian),
+            "simple" | "ma" | "simple_moving_average" => {
+                Ok(PyConstantModelType::SimpleMovingAverage)
+            }
+            "smoothed" | "sma" | "smoothed_moving_average" => {
+                Ok(PyConstantModelType::SmoothedMovingAverage)
+            }
+            "exponential" | "ema" | "exponential_moving_average" => {
+                Ok(PyConstantModelType::ExponentialMovingAverage)
+            }
+            "median" | "smm" | "simple_moving_median" => {
+                Ok(PyConstantModelType::SimpleMovingMedian)
+            }
             "mode" | "simple_moving_mode" => Ok(PyConstantModelType::SimpleMovingMode),
             _ => Err(PyValueError::new_err(format!(
-                "Unknown constant model type: '{}'. Valid options are: 'simple', 'smoothed', 'exponential', 'median', 'mode'", 
+                "Unknown constant model type: '{}'. Valid options (case-insensitive) are: \
+                 'simple' | 'ma' | 'simple_moving_average', \
+                 'smoothed' | 'sma' | 'smoothed_moving_average', \
+                 'exponential' | 'ema' | 'exponential_moving_average', \
+                 'median' | 'smm' | 'simple_moving_median', \
+                 'mode' | 'simple_moving_mode'. Note: 'ma' = Simple, 'sma' = Smoothed",
                 s
-            )))
+            ))),
         }
     }
 }
@@ -56,6 +83,19 @@ impl From<PyConstantModelType> for ConstantModelType {
 }
 
 impl PyDeviationModel {
+    /// Parse a `DeviationModel` from a string alias (matching is case-insensitive).
+    ///
+    /// Each variant accepts a primary one-word form plus a long snake_case form (and `log`
+    /// additionally accepts the `logstd` abbreviation). The full accepted set is:
+    ///
+    /// - `standard` | `std` | `standard_deviation` → Standard deviation
+    /// - `mean` | `mean_absolute_deviation` → Mean absolute deviation
+    /// - `median` | `median_absolute_deviation` → Median absolute deviation
+    /// - `mode` | `mode_absolute_deviation` → Mode absolute deviation
+    /// - `ulcer` | `ulcer_index` → Ulcer index
+    /// - `log` | `logstd` | `log_standard_deviation` → Log standard deviation
+    /// - `laplace` | `laplace_std_equivalent` → Laplace std equivalent
+    /// - `cauchy` | `cauchy_iqr_scale` → Cauchy IQR scale
     pub fn from_string(s: &str) -> PyResult<Self> {
         let lower = s.to_lowercase();
 
@@ -65,13 +105,23 @@ impl PyDeviationModel {
             "median" | "median_absolute_deviation" => Ok(PyDeviationModel::MedianAbsoluteDeviation),
             "mode" | "mode_absolute_deviation" => Ok(PyDeviationModel::ModeAbsoluteDeviation),
             "ulcer" | "ulcer_index" => Ok(PyDeviationModel::UlcerIndex),
-            "log" | "log_standard_deviation" | "logstd" => Ok(PyDeviationModel::LogStandardDeviation),
+            "log" | "log_standard_deviation" | "logstd" => {
+                Ok(PyDeviationModel::LogStandardDeviation)
+            }
             "laplace" | "laplace_std_equivalent" => Ok(PyDeviationModel::LaplaceStdEquivalent),
             "cauchy" | "cauchy_iqr_scale" => Ok(PyDeviationModel::CauchyIQRScale),
             _ => Err(PyValueError::new_err(format!(
-                "Unknown deviation model: '{}'. Valid options are: 'standard', 'mean', 'median', 'mode', 'ulcer', 'log', 'laplace', 'cauchy'",
+                "Unknown deviation model: '{}'. Valid options (case-insensitive) are: \
+                 'standard' | 'std' | 'standard_deviation', \
+                 'mean' | 'mean_absolute_deviation', \
+                 'median' | 'median_absolute_deviation', \
+                 'mode' | 'mode_absolute_deviation', \
+                 'ulcer' | 'ulcer_index', \
+                 'log' | 'logstd' | 'log_standard_deviation', \
+                 'laplace' | 'laplace_std_equivalent', \
+                 'cauchy' | 'cauchy_iqr_scale'",
                 s
-            )))
+            ))),
         }
     }
 }
@@ -111,15 +161,27 @@ pub enum PyMovingAverageType {
 }
 
 impl PyMovingAverageType {
+    /// Parse a `MovingAverageType` from a string alias (matching is case-insensitive).
+    ///
+    /// Accepts **only** the three primary one-word forms — no abbreviations, no snake_case:
+    ///
+    /// - `simple` → Simple
+    /// - `smoothed` → Smoothed
+    /// - `exponential` → Exponential
+    ///
+    /// This is the opposite of [`PyConstantModelType::from_string`]: the abbreviations
+    /// `ma`/`sma`/`ema` and snake_case forms like `simple_moving_average` raise `ValueError`
+    /// here.
     pub fn from_string(s: &str) -> PyResult<Self> {
         match s.to_lowercase().as_str() {
             "simple" => Ok(PyMovingAverageType::Simple),
             "smoothed" => Ok(PyMovingAverageType::Smoothed),
             "exponential" => Ok(PyMovingAverageType::Exponential),
             _ => Err(PyValueError::new_err(format!(
-                "Unknown moving average type: '{}'. Valid options are: 'simple', 'smoothed', 'exponential'",
+                "Unknown moving average type: '{}'. Valid options (case-insensitive) are: \
+                 'simple', 'smoothed', 'exponential' (no abbreviations or snake_case forms)",
                 s
-            )))
+            ))),
         }
     }
 }

--- a/tests/test_string_aliases.py
+++ b/tests/test_string_aliases.py
@@ -1,0 +1,60 @@
+"""Pin the accepted string-alias sets for the three string-parsed regimes.
+
+These tests lock the model-type / deviation-model / moving-average-type aliases to their
+results so the mapping can't silently drift. Each alias is asserted to produce the *same*
+result as its canonical one-word form, and invalid strings must raise ``ValueError``.
+
+Three vocabularies are in play for ConstantModelType / DeviationModel: a primary one-word
+form, a short abbreviation, and a long snake_case form. The notable traps are ``ma`` ->
+Simple and ``sma`` -> Smoothed. MovingAverageType is deliberately stricter: it accepts only
+the three one-word forms and rejects the abbreviations.
+"""
+
+import math
+
+import pytest
+
+from centaur_technical_indicators import momentum_indicators as mom
+from centaur_technical_indicators import candle_indicators as can
+from centaur_technical_indicators import moving_average as ma
+
+PRICES = [100.0, 101.0, 102.0, 101.5, 102.5, 103.0, 102.0]
+
+
+def same(a, b):  # NaN != NaN, so treat two NaNs as equal
+    if isinstance(a, float) and isinstance(b, float):
+        return a == b or (math.isnan(a) and math.isnan(b))
+    return a == b  # tuples compare elementwise
+
+
+def test_constant_model_aliases():
+    rsi = lambda m: mom.single.relative_strength_index(PRICES, m)
+    assert same(rsi("ma"), rsi("simple")) and same(rsi("simple_moving_average"), rsi("simple"))
+    assert same(rsi("sma"), rsi("smoothed")) and same(rsi("smoothed_moving_average"), rsi("smoothed"))
+    assert same(rsi("ema"), rsi("exponential")) and same(rsi("exponential_moving_average"), rsi("exponential"))
+    assert same(rsi("smm"), rsi("median")) and same(rsi("simple_moving_median"), rsi("median"))
+    assert same(rsi("simple_moving_mode"), rsi("mode"))
+    with pytest.raises(ValueError):
+        rsi("not_a_model")
+
+
+def test_deviation_model_aliases():
+    band = lambda d: can.single.moving_constant_bands(PRICES, "simple", d, 3.0)
+    assert band("std") == band("standard") == band("standard_deviation")
+    assert band("mean") == band("mean_absolute_deviation")
+    assert band("median") == band("median_absolute_deviation")
+    assert band("mode") == band("mode_absolute_deviation")
+    assert band("ulcer") == band("ulcer_index")
+    assert band("log") == band("logstd") == band("log_standard_deviation")
+    assert band("laplace") == band("laplace_std_equivalent")
+    assert band("cauchy") == band("cauchy_iqr_scale")
+    with pytest.raises(ValueError):
+        band("not_a_model")
+
+
+def test_moving_average_type_only_three():
+    mav = lambda m: ma.single.moving_average(PRICES, m)
+    mav("simple"); mav("smoothed"); mav("exponential")  # accepted
+    for rejected in ("ma", "sma", "ema", "simple_moving_average", "nope"):
+        with pytest.raises(ValueError):
+            mav(rejected)


### PR DESCRIPTION
## Summary

Makes the accepted string-alias sets for the three `from_string` regimes in `src/lib.rs` **honest and tested**, without changing any behavior. Three vocabularies were silently in play — primary one-word forms (in tests + error messages), 3-letter abbreviations (only in the match arms, undocumented), and long snake_case forms (only in function docstrings) — which hid two traps: `"ma"` → **Simple** and `"sma"` → **Smoothed**, and the fact that `PyMovingAverageType` rejects the abbreviations `PyConstantModelType` accepts.

- **Docs:** Added `///` doc comments to `PyConstantModelType`, `PyDeviationModel`, and `PyMovingAverageType` `from_string`, each listing the complete accepted alias set for that regime, calling out `ma`→Simple / `sma`→Smoothed, and noting MovingAverageType takes only the three one-word forms.
- **Error messages:** Expanded each `_ =>` error string to list the full accepted set (canonical + abbreviation + snake_case), reconciling the error-vs-docstring drift.
- **Tests:** New `tests/test_string_aliases.py` pins every accepted alias to its canonical result and asserts invalid strings raise `ValueError`, including MA-type rejecting abbreviations.

Match patterns and their mappings are unchanged — the only Rust changes are doc comments, error-string wording, and `cargo fmt`-induced brace wrapping of long arms.

## Compatibility

None — behavior is identical. No alias added or removed; no mapping changed. Only `from_string` error-message text changed (a string, not which inputs are accepted).

## Validation

- `cargo fmt --all -- --check` — clean
- `maturin develop` — builds cleanly
- `python -m pytest tests/test_string_aliases.py -q` — 3 passed
- `python -m pytest -q` — 103 passed (full suite, no regressions)

## Changelog

Added under `## [Unreleased]`:
```
### Added
- Tests pinning accepted model-type / deviation-model / moving-average-type string aliases.
- Documentation of the full accepted string-alias set for each regime (incl. the `sma`→Smoothed
  / `ma`→Simple aliases), with `from_string` error messages reconciled to match.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)