### PR TITLE
feat: bind chart_trends peak/valley favorable move

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Incorrect `Documentation` URL in package metadata (pointed at the GitHub wiki).
 
 ### Added
+- `chart_trends.peak_favorable_move` and `chart_trends.valley_favorable_move` bindings (maximum
+  favorable excursion over a forward window), mirroring Rust 1.3.0.
 - `cargo fmt --check` step to CI (the `verify` job in `CI.yml`).
 - `docs/2.0.0.md` breaking-change backlog.
 - Tests pinning accepted model-type / deviation-model / moving-average-type string aliases.

--- a/src/chart_trends.rs
+++ b/src/chart_trends.rs
@@ -19,6 +19,8 @@ pub fn chart_trends(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(valley_trend, m)?)?;
     m.add_function(wrap_pyfunction!(overall_trend, m)?)?;
     m.add_function(wrap_pyfunction!(break_down_trends, m)?)?;
+    m.add_function(wrap_pyfunction!(peak_favorable_move, m)?)?;
+    m.add_function(wrap_pyfunction!(valley_favorable_move, m)?)?;
     Ok(())
 }
 
@@ -138,4 +140,42 @@ fn break_down_trends(
         },
     )
     .map_err(|e| PyValueError::new_err(e.to_string()))
+}
+
+/// Calculates the peak favorable move for the price at a given index.
+///
+/// The favorable move is the largest drop from `prices[index]` to the lowest price in the
+/// inclusive forward window `[index + 1, index + period]`. The result is signed: it is negative
+/// when no price in the window falls below `prices[index]`.
+///
+/// Args:
+///     prices: List of prices
+///     index: Index of the reference price
+///     period: Number of bars in the forward window
+///
+/// Returns:
+///     The signed favorable move (`prices[index] - min(window)`)
+#[pyfunction]
+fn peak_favorable_move(prices: Vec<f64>, index: usize, period: usize) -> PyResult<f64> {
+    ct::peak_favorable_move(&prices, index, period)
+        .map_err(|e| PyValueError::new_err(e.to_string()))
+}
+
+/// Calculates the valley favorable move for the price at a given index.
+///
+/// The favorable move is the largest rise from `prices[index]` to the highest price in the
+/// inclusive forward window `[index + 1, index + period]`. The result is signed: it is negative
+/// when no price in the window rises above `prices[index]`.
+///
+/// Args:
+///     prices: List of prices
+///     index: Index of the reference price
+///     period: Number of bars in the forward window
+///
+/// Returns:
+///     The signed favorable move (`max(window) - prices[index]`)
+#[pyfunction]
+fn valley_favorable_move(prices: Vec<f64>, index: usize, period: usize) -> PyResult<f64> {
+    ct::valley_favorable_move(&prices, index, period)
+        .map_err(|e| PyValueError::new_err(e.to_string()))
 }

--- a/tests/test_chart_trends.py
+++ b/tests/test_chart_trends.py
@@ -1,3 +1,5 @@
+import pytest
+
 from centaur_technical_indicators import chart_trends
 
 """The purpose of these tests are just to confirm that the bindings work.
@@ -54,5 +56,29 @@ def test_break_down_trends():
     )
    
     assert trends == [(0, 2, 1.5, 100.16666666666667), (2, 4, -2.0, 107.0)]
+
+
+def test_peak_favorable_move():
+    # Reference 107; forward window [104, 100, 102]; 107 - min(100) = 7.0
+    assert chart_trends.peak_favorable_move([107.0, 104.0, 100.0, 102.0], 0, 3) == 7.0
+    # Monotonic rise: price never drops below the reference, so the move is negative.
+    assert chart_trends.peak_favorable_move([100.0, 101.0, 102.0, 103.0], 0, 3) == -1.0
+
+def test_valley_favorable_move():
+    # Reference 100; forward window [102, 107, 104]; max(107) - 100 = 7.0
+    assert chart_trends.valley_favorable_move([100.0, 102.0, 107.0, 104.0], 0, 3) == 7.0
+    # Monotonic fall: price never rises above the reference, so the move is negative.
+    assert chart_trends.valley_favorable_move([105.0, 104.0, 103.0, 102.0], 0, 3) == -1.0
+
+def test_favorable_move_invalid_input():
+    # Empty prices -> EmptyData -> ValueError
+    with pytest.raises(ValueError):
+        chart_trends.peak_favorable_move([], 0, 3)
+    # period == 0 -> InvalidPeriod -> ValueError
+    with pytest.raises(ValueError):
+        chart_trends.peak_favorable_move([100.0, 101.0, 102.0], 0, 0)
+    # Forward window out of bounds (index + period >= len) -> InvalidPeriod -> ValueError
+    with pytest.raises(ValueError):
+        chart_trends.valley_favorable_move([100.0, 101.0, 102.0], 1, 3)
 
 


### PR DESCRIPTION
## Summary

Bind the two new Rust 1.3.0 chart-trend functions as **flat** functions on `chart_trends`, mirroring `peaks`/`valleys`:

- `chart_trends.peak_favorable_move(prices, index, period) -> float`
- `chart_trends.valley_favorable_move(prices, index, period) -> float`

Each returns the maximum favorable excursion over the **inclusive** forward window `[index+1, index+period]`. Result is **signed** (negative when no window price moves favorably past the reference). Upstream errors map to `ValueError` (empty → `EmptyData`; `period == 0` and out-of-bounds window → `InvalidPeriod`).

## Compatibility

Purely additive — two new functions; no change to existing bindings or signatures. No new dependencies. `[package] version` stays `1.2.2` (bumped once at the release cut, per the staged-release plan).

## Validation

- `maturin develop` — clean
- `python -m pytest` — **106 passed**
- `cargo fmt --all -- --check` — clean

Exact-value tests trace each result through the 1.3.0 algorithm and were confirmed by running the binding (`7.0 / -1.0 / 7.0 / -1.0`); `ValueError` is asserted for empty input, zero period, and an out-of-bounds window.

## Changelog

Added under `[Unreleased]`:
- `chart_trends.peak_favorable_move` and `chart_trends.valley_favorable_move` bindings (maximum favorable excursion over a forward window), mirroring Rust 1.3.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)