### PR TITLE
test: inherited-fix regression tests + carryover Fixed changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 - Incorrect `Documentation` URL in package metadata (pointed at the GitHub wiki).
+- Inherited Rust 1.3.0 behavior changes, now user-visible through the bindings:
+  `chart_trends.peaks` / `chart_trends.valleys` corrected for index-0 and
+  retained-after-monotonic-run extrema; and `aroon_up` / `aroon_down` /
+  `stochastic_oscillator` return `NaN` instead of panicking on all-NaN input.
 
 ### Added
+- Python regression tests for inherited Rust 1.3.0 chart-trend / degenerate-input fixes.
 - `chart_trends.peak_favorable_move` and `chart_trends.valley_favorable_move` bindings (maximum
   favorable excursion over a forward window), mirroring Rust 1.3.0.
 - `cargo fmt --check` step to CI (the `verify` job in `CI.yml`).

--- a/tests/test_candle_indicators.py
+++ b/tests/test_candle_indicators.py
@@ -144,6 +144,12 @@ def test_bulk_supertrend():
     with pytest.raises(ValueError):
         candle_indicators.bulk.supertrend(high, low, close, "", 2.0, 3)
 
+def test_cauchy_degenerate_moving_constant_bands_no_panic():
+    """Regression: flat input (IQR=0) must not panic through FFI; hardened cauchy path returns finite bands."""
+    result = candle_indicators.single.moving_constant_bands([100., 100., 100., 100.], "simple", "cauchy", 3.0)
+    assert result == (100.0, 100.0, 100.0)
+
+
 def test_new_deviation_models_moving_constant_bands():
     """Test new probability distribution deviation models added in rust_ti 2.2.0"""
     # Test log standard deviation

--- a/tests/test_chart_trends.py
+++ b/tests/test_chart_trends.py
@@ -70,6 +70,16 @@ def test_valley_favorable_move():
     # Monotonic fall: price never rises above the reference, so the move is negative.
     assert chart_trends.valley_favorable_move([105.0, 104.0, 103.0, 102.0], 0, 3) == -1.0
 
+def test_peaks_keeps_valid_index_zero_peak():
+    """Regression: index-0 extremum must not be dropped (Rust 1.3.0 fix)."""
+    assert chart_trends.peaks([110., 109., 108., 107.], 2, 1) == [(110.0, 0)]
+
+
+def test_peaks_does_not_drop_retained_peak_after_monotonic_run():
+    """Regression: peak retained after a monotonic run must survive (Rust 1.3.0 fix)."""
+    assert chart_trends.peaks([110., 109., 108., 120.], 2, 2) == [(110.0, 0), (120.0, 3)]
+
+
 def test_favorable_move_invalid_input():
     # Empty prices -> EmptyData -> ValueError
     with pytest.raises(ValueError):

--- a/tests/test_momentum_indicators.py
+++ b/tests/test_momentum_indicators.py
@@ -1,3 +1,4 @@
+import math
 import pytest
 
 from centaur_technical_indicators import momentum_indicators
@@ -269,6 +270,11 @@ def test_single_chande_momentum_oscillator():
 
 def test_bulk_chande_momentum_oscillator():
     assert momentum_indicators.bulk.chande_momentum_oscillator(prices, 3) == [100.0, -33.33333333333333, -100.0]
+
+def test_all_nan_stochastic_returns_nan_not_panic():
+    result = momentum_indicators.single.stochastic_oscillator([float("nan"), float("nan")])
+    assert math.isnan(result)
+
 
 def test_new_deviation_models_commodity_channel_index():
     """Test new probability distribution deviation models added in rust_ti 2.2.0"""

--- a/tests/test_trend_indicators.py
+++ b/tests/test_trend_indicators.py
@@ -1,3 +1,4 @@
+import math
 import pytest
 
 from centaur_technical_indicators import trend_indicators
@@ -27,6 +28,16 @@ high = [200.0, 210.0, 205.0, 190.0, 185.0]
 low = [175.0, 192.0, 200.0, 174.0, 179.0]
 close = [192.0, 200.0, 201.0, 187.0, 188.0]
 volume = [1000.0, 1500.0, 1200.0, 900.0, 1300.0]
+
+def test_all_nan_aroon_up_returns_nan_not_panic():
+    result = trend_indicators.single.aroon_up([float("nan"), float("nan")])
+    assert math.isnan(result)
+
+
+def test_all_nan_aroon_down_returns_nan_not_panic():
+    result = trend_indicators.single.aroon_down([float("nan"), float("nan")])
+    assert math.isnan(result)
+
 
 def test_single_aroon_up():
     assert trend_indicators.single.aroon_up(high) == 25.0


### PR DESCRIPTION
> **Stacked on #38 (S2).** Based on `feat/favorable-move` so this diff shows only S3's changes; GitHub will auto-retarget the base to `main` when #38 merges.

## Summary

FFI-boundary regression tests proving the inherited Rust 1.3.0 fixes hold through the bindings, plus the inherited-behavior `Fixed` changelog entry the dep-bump PR (#32) merged without. **Tests + changelog only — no `src` changes.**

- all-NaN `stochastic_oscillator` / `aroon_up` / `aroon_down` → `NaN` (no panic crossing FFI)
- degenerate (flat) `moving_constant_bands(…, "cauchy", …)` → no panic (cauchy reachable only via `deviation_model="cauchy"`; there is no `cauchy_iqr_scale` binding)
- `chart_trends.peaks` index-0 retention and retained-after-monotonic-run corrections

## Compatibility

None — additive tests + documentation. No new dependencies; `Cargo.lock` unchanged.

## Validation

- `maturin develop` — clean
- `python -m pytest` — **112 passed** (106 + 6 new)
- `cargo fmt --all -- --check` — clean

All expected values were generated against the installed 1.3.0 build.

## Changelog

`Fixed`: inherited Rust 1.3.0 behavior (peaks/valleys index-0 & retained-after-monotonic-run; aroon/stochastic NaN-not-panic on all-NaN). `Added`: Python regression tests for the inherited fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)