### PR TITLE
chore: release 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ---
 
-## [Unreleased]
+## [1.3.0] - 2026-06-20
 
 ### Fixed
 - Incorrect `Documentation` URL in package metadata (pointed at the GitHub wiki).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,9 +10,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "centaur_technical_indicators"
-version = "1.2.2"
+version = "1.3.0"
 dependencies = [
- "centaur_technical_indicators 1.3.0",
+ "centaur_technical_indicators 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pyo3",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "centaur_technical_indicators"
-version = "1.2.2"
+version = "1.3.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
## Summary

Cut 1.3.0: bump `[package] version` `1.2.2` → `1.3.0` and promote the changelog. The single version edit drives both the wheel version and (via S7's `importlib.metadata` mixed layout) `cti.__version__`.

> **Merge order:** merge **#42 (decision docs)** first, then this PR, **then** push the `v1.3.0` tag — so the tag contains `docs/DECISIONS-1.3.0.md`.

## Compatibility

Release only — no API/behavior change. The dependency was already `1.3.0` (bumped in #32); this flips the package version that was deliberately staged behind it.

## Validation

- `maturin develop` — clean; **`cti.__version__` → `1.3.0`** (decisive check)
- `python -m pytest` — **116 passed**
- `cargo fmt --all -- --check` — clean
- `Cargo.lock` regenerated (package version only)

## Changelog

Promoted `## [Unreleased]` → `## [1.3.0] - 2026-06-20` (no content change; consolidates the per-slice entries).

## Release / publish (maintainer)

After this and #42 merge, push the **`v1.3.0`** tag on the merge commit. CI's `release` job (tag-triggered) builds all-platform wheels + sdist and `uv publish`es to PyPI via `UV_PUBLISH_TOKEN`. **I have not tagged or published** — that's the maintainer's action. The `pyproject.toml` author email placeholder is intentionally retained (1.3.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)