### PR TITLE
chore: bump PyO3 to 0.29 (security GHSA-36hh / GHSA-chgr)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ---
 
+## [Unreleased]
+
+### Security
+- Bumped PyO3 from 0.25 to 0.29, resolving GHSA-36hh-v3qg-5jq4 (out-of-bounds read in the
+  `nth`/`nth_back` iterators of `PyList`/`PyTuple`) and GHSA-chgr-c6px-7xpp (missing `Sync` bound
+  on `PyCFunction::new_closure`). Neither vulnerable path is exercised by these bindings; the bump
+  clears both advisories at the dependency level.
+
+### Changed
+- Declared `rust-version = "1.83"` in `Cargo.toml` — the minimum supported Rust the PyO3 0.29
+  bump requires (no impact on prebuilt wheels; relevant only when building from source).
+
+---
+
 ## [1.3.0] - 2026-06-20
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,12 +3,6 @@
 version = 4
 
 [[package]]
-name = "autocfg"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
-
-[[package]]
 name = "centaur_technical_indicators"
 version = "1.3.0"
 dependencies = [
@@ -29,25 +23,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "indoc"
-version = "2.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
-
-[[package]]
 name = "libc"
 version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
-
-[[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
-]
 
 [[package]]
 name = "once_cell"
@@ -72,36 +51,32 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.25.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8970a78afe0628a3e3430376fc5fd76b6b45c4d43360ffd6cdd40bdde72b682a"
+checksum = "cd274650b21d4bfc26a0a47587962c1edb425f69287324355cd040c3ea66071c"
 dependencies = [
- "indoc",
  "libc",
- "memoffset",
  "once_cell",
  "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
- "unindent",
 ]
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.25.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "458eb0c55e7ece017adeba38f2248ff3ac615e53660d7c71a238d7d2a01c7598"
+checksum = "c5e2a7d2f0d013342f295c048ad19237add5154a55b1c5a254c0ec93d4109078"
 dependencies = [
- "once_cell",
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.25.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7114fe5457c61b276ab77c5055f206295b812608083644a5c5b2640c3102565c"
+checksum = "ca85c467da1bbc8d866eea5deff9cf29ea5f7785054a17da36e65bda9c05845b"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -109,9 +84,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.25.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8725c0a622b374d6cb051d11a0983786448f7785336139c3c94f5aa6bef7e50"
+checksum = "9ac53762fd065daa3194dd09337a38bd793a188100fd1a9304c4ab312d901771"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -121,13 +96,12 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.25.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4109984c22491085343c05b0dbc54ddc405c3cf7b4374fc533f5c3313a572ccc"
+checksum = "4ca3a1557399783172dc5bf39cfca835157732532cba56b71d2292161e53b362"
 dependencies = [
  "heck",
  "proc-macro2",
- "pyo3-build-config",
  "quote",
  "syn",
 ]
@@ -154,18 +128,12 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.13.2"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e502f78cdbb8ba4718f566c418c52bc729126ffd16baee5baa718cf25dd5a69a"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
-
-[[package]]
-name = "unindent"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "centaur_technical_indicators"
 version = "1.3.0"
 edition = "2021"
+rust-version = "1.83"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]
@@ -9,5 +10,5 @@ name = "centaur_technical_indicators"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = "0.25.0"
+pyo3 = "0.29"
 centaur_technical_indicators = "1.3.0"


### PR DESCRIPTION
## Summary
Bump PyO3 from 0.25 to 0.29 to clear two Dependabot advisories affecting the shipped binding:
- **GHSA-36hh-v3qg-5jq4** (HIGH, CVSS 8.7) — out-of-bounds read in `nth`/`nth_back` for `PyList`/`PyTuple` iterators.
- **GHSA-chgr-c6px-7xpp** (medium) — missing `Sync` bound on `PyCFunction::new_closure`.

`0.29.0` is simultaneously the first patched release and the current latest stable. Neither vulnerable code path is invoked by this binding, so both advisories are cleared at the dependency level. The entire `IntoPyObject` return-value migration predates the existing 0.25 pin, so **no source changes were required** — `maturin develop` compiled cleanly against 0.29 with zero `src/` edits.

## Scope
- **Changed:** `Cargo.toml` (`pyo3 = "0.29"`; added `rust-version = "1.83"`), `Cargo.lock` (regenerated — pyo3 + `pyo3-ffi`/`pyo3-macros`/`pyo3-macros-backend`/`pyo3-build-config` → 0.29.0; the lock dropped 4 now-unused transitive crates), `CHANGELOG.md`.
- **Intentionally untouched:** all `src/**`, `tests/**`; `[package] version` (stays `1.3.0` — the version cut is a separate, later batch); the `centaur_technical_indicators` core dependency (stays `1.3.0`); CI workflows; `pyproject.toml`.

## Compatibility
N/A — no API or behavior change; the public binding surface is identical. This is a dependency security bump. The new **MSRV of Rust 1.83** (introduced by PyO3 0.29) affects only building from source — prebuilt wheels are unaffected, and CI runners use current stable Rust (1.94).

## Validation
- `maturin develop` — clean; **zero `src/` edits required** (the decisive check).
- `python -m pytest` — **116 passed** (identical to the pre-bump baseline).
- `cargo fmt --all -- --check` — clean.

## Changelog
Added under a newly created `## [Unreleased]`:
```
### Security
- Bumped PyO3 from 0.25 to 0.29, resolving GHSA-36hh-v3qg-5jq4 (out-of-bounds read in the
  `nth`/`nth_back` iterators of `PyList`/`PyTuple`) and GHSA-chgr-c6px-7xpp (missing `Sync` bound
  on `PyCFunction::new_closure`). Neither vulnerable path is exercised by these bindings; the bump
  clears both advisories at the dependency level.

### Changed
- Declared `rust-version = "1.83"` in `Cargo.toml` — the minimum supported Rust the PyO3 0.29
  bump requires (no impact on prebuilt wheels; relevant only when building from source).
```

## Notes
- **Merge ordering:** this PR and the companion test-deps PR (`chore/bump-test-deps-security`) each introduce a `## [Unreleased]` + `### Security` heading. Whichever merges **second** will hit a trivial `CHANGELOG.md` conflict and should rebase to consolidate both entries under a single `### Security` block.
- _AI assistance: implemented with Claude Code (Opus 4.8) in an isolated git worktree; disclosed per CONTRIBUTING.md._
