### PR TITLE
chore: bump pytest 9.0.3 + Pygments 2.20.0 (security)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ---
 
+## [Unreleased]
+
+### Security
+- Bumped test-only tooling: pytest 8.4.1 → 9.0.3 (resolves GHSA-6w46-j5rx-g56g, vulnerable tmpdir
+  handling) and Pygments 2.19.2 → 2.20.0 (resolves GHSA-5239-wwwm-4pmq, ReDoS in the GUID-matching
+  regex). Development/CI dependencies only — no runtime or API impact on the installed package.
+
+---
+
 ## [1.3.0] - 2026-06-20
 
 ### Fixed

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -2,5 +2,5 @@ iniconfig==2.1.0
 maturin==1.11.5
 packaging==25.0
 pluggy==1.6.0
-Pygments==2.19.2
-pytest==8.4.1
+Pygments==2.20.0
+pytest==9.0.3


### PR DESCRIPTION
## Summary
Bump the two vulnerable **test-only** pins in `test_requirements.txt` to clear their Dependabot advisories:
- **pytest** `8.4.1` → `9.0.3` — **GHSA-6w46-j5rx-g56g** (medium; vulnerable tmpdir handling).
- **Pygments** `2.19.2` → `2.20.0` — **GHSA-5239-wwwm-4pmq** (low; ReDoS in the GUID-matching regex).

pytest 9 keeps the Python 3.10 floor (matches `requires-python >=3.10` and the 3.10–3.14 CI matrix) and forces no transitive-pin bumps. The smoke suite passes unchanged under pytest 9.0.3.

## Scope
- **Changed:** `test_requirements.txt` (pytest + Pygments), `CHANGELOG.md`.
- **Intentionally untouched:** `pluggy` / `iniconfig` / `packaging` / `maturin` pins (pytest 9.0.3's constraints `pluggy>=1.5,<2` / `iniconfig>=1.0.1` / `packaging>=22` are already satisfied); `requirements.txt`; all `src/**`, `tests/**`, `Cargo.*`, CI, `pyproject.toml`.

## Compatibility
N/A — development/CI tooling only. pytest and Pygments never ship in the installed wheel, so there is no runtime or API impact for users of the package.

## Validation
- `pytest --version` → **9.0.3**.
- `maturin develop && python -m pytest` — **116 passed**, fully green (same count as the 8.4.1 baseline; no failures, no deprecation-raised-as-error).
- `cargo fmt --all -- --check` — clean.
- `pip freeze` confirms `pluggy==1.6.0`, `iniconfig==2.1.0`, `packaging==25.0`, `maturin==1.11.5` unchanged.

## Changelog
Added under a newly created `## [Unreleased]`:
```
### Security
- Bumped test-only tooling: pytest 8.4.1 → 9.0.3 (resolves GHSA-6w46-j5rx-g56g, vulnerable tmpdir
  handling) and Pygments 2.19.2 → 2.20.0 (resolves GHSA-5239-wwwm-4pmq, ReDoS in the GUID-matching
  regex). Development/CI dependencies only — no runtime or API impact on the installed package.
```
_The `### Security` entry for a test-only bump is **intentional** — transparency about the advisories this security release closes — not an oversight per the changelog "non-user-facing" exemption._

## Notes
- **Merge ordering:** this PR and the companion PyO3 PR (`chore/bump-pyo3-0.29`) each introduce a `## [Unreleased]` + `### Security` heading. Whichever merges **second** should rebase to consolidate both entries under one `### Security` block.
- pytest 9 adds an informational `configfile: pyproject.toml` line to its header output (it picks up the existing `pyproject.toml` rootdir) — not a warning; `pyproject.toml` was not modified.
- _AI assistance: implemented with Claude Code (Opus 4.8) in an isolated git worktree; disclosed per CONTRIBUTING.md._
