### PR TITLE
docs: refresh AGENTS.md core-crate version source-of-truth note

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,7 +113,7 @@ For parallel or batched work (e.g. running multiple slice briefs):
 
 ## Core-crate version & source of truth
 - The binding wraps the published crates.io crate `centaur_technical_indicators`; that core-crate version is the source of truth, and `[package] version` in `Cargo.toml` is normally bumped to match it (see `docs/REPO_MAP.md` for the full rule).
-- Current in-flight state on `main`: the dependency is pinned to `1.3.0` while `[package] version` is intentionally held at `1.2.2` until the release cut — deferred deliberately, not forgotten.
+- `[package] version` need **not** always equal the core-crate version. A **binding-only patch release** — one that changes only the bindings/tooling (e.g. the 1.3.1 security patch: PyO3 and test-tooling bumps, no core-crate code) — may move `[package] version` ahead while the `centaur_technical_indicators` dependency stays put. The version-match rule above is the default; binding-only patches are the documented exception. *(Example: 1.3.1 ships `[package] version = 1.3.1` against core crate `1.3.0`.)*
 
 ## Pull request checklist for agents
 - [ ] Scope is minimal and matches the task; only the named files changed.


### PR DESCRIPTION
## Summary
Refresh the "Core-crate version & source of truth" note in `AGENTS.md`. The second bullet still claimed `[package] version` is "held at `1.2.2` until the release cut" — stale since the 1.3.0 cut shipped (`Cargo.toml` `version = 1.3.0`). It is replaced with a durable rule: a **binding-only patch release** (e.g. the 1.3.1 security patch — PyO3 / test-tooling bumps, no core-crate code) may move `[package] version` ahead of the `centaur_technical_indicators` core crate, which stays put. Version-match remains the default; binding-only patches are the documented exception, with 1.3.1 (`[package] 1.3.1` vs core `1.3.0`) as the worked example.

This governs the deliberate version divergence the 1.3.1 release introduces, rather than leaving it ad hoc.

## Scope
- **Changed:** `AGENTS.md` — only the second bullet of the "Core-crate version & source of truth" section (1 line replaced). The first bullet (match-rule + `docs/REPO_MAP.md` pointer) is unchanged.
- **Intentionally untouched:** every other `AGENTS.md` section, `docs/REPO_MAP.md`, and all code/config.

## Compatibility
N/A — documentation only.

## Validation
- `cargo fmt --all -- --check` — clean (confirms no Rust drift).
- `git diff --stat` — only `AGENTS.md`, `1 insertion(+), 1 deletion(-)`, confined to the one section.
- `maturin develop` / `python -m pytest` not run — a Markdown-only change to `AGENTS.md` cannot affect the build or test results.

## Changelog
Exempt — non-user-facing governance/docs change (the `AGENTS.md` changelog-coupling exception). No `CHANGELOG.md` entry.

## Notes
- **Authorization:** `AGENTS.md` is normally read-only governance. The maintainer explicitly authorized this specific edit (scoped to the "Core-crate version & source of truth" section only).
- _AI assistance: implemented with Claude Code (Opus 4.8) in an isolated git worktree; disclosed per CONTRIBUTING.md._
