### PR TITLE
chore: release 1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ---
 
-## [Unreleased]
+## [1.3.1] - 2026-06-21
 
 ### Security
 - Bumped test-only tooling: pytest 8.4.1 → 9.0.3 (resolves GHSA-6w46-j5rx-g56g, vulnerable tmpdir

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,16 +5,16 @@ version = 4
 [[package]]
 name = "centaur_technical_indicators"
 version = "1.3.0"
-dependencies = [
- "centaur_technical_indicators 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pyo3",
-]
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41f1d42ebb4f20df394539be4afd1a21f69a6f18c7ab9ae3a8eaeac7929e1bfb"
 
 [[package]]
 name = "centaur_technical_indicators"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f1d42ebb4f20df394539be4afd1a21f69a6f18c7ab9ae3a8eaeac7929e1bfb"
+version = "1.3.1"
+dependencies = [
+ "centaur_technical_indicators 1.3.0",
+ "pyo3",
+]
 
 [[package]]
 name = "heck"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "centaur_technical_indicators"
-version = "1.3.0"
+version = "1.3.1"
 edition = "2021"
 rust-version = "1.83"
 


### PR DESCRIPTION
## Summary
Cut the **1.3.1** release — a binding-only security patch. Bumps `[package] version` 1.3.0 → 1.3.1 and promotes `## [Unreleased]` → `## [1.3.1] - 2026-06-21`. The `centaur_technical_indicators` core crate dependency **stays at 1.3.0** — a deliberate, now-documented divergence (binding-only patches may move the package version ahead of the core crate; see the AGENTS.md note added in #46).

1.3.1 ships the security work already merged for this release:
- **PyO3 0.25 → 0.29** (#44) — clears GHSA-36hh-v3qg-5jq4 (HIGH) and GHSA-chgr-c6px-7xpp.
- **pytest 9.0.3 / Pygments 2.20.0** (#45) — clears GHSA-6w46-j5rx-g56g and GHSA-5239-wwwm-4pmq.

All six Dependabot alerts (#2–#7) are now `state=fixed` (0 open).

## Scope
- **Changed:** `Cargo.toml` (`[package] version` → 1.3.1), `Cargo.lock` (this package's own node → 1.3.1; pyo3 stays 0.29.0; no third-party version moved), `CHANGELOG.md` (heading promote only — no content change).
- **Intentionally untouched:** the core dependency (stays 1.3.0), `src/**`, `tests/**`, `test_requirements.txt`, `AGENTS.md`, CI, and `pyproject.toml` (the author/maintainer `your@email.com` placeholder remains deferred to a later release).

## Compatibility
Release only — no API or behavior change. `cti.__version__` resolves to `1.3.1`.

## Validation
- `maturin develop` clean; `python -c "import centaur_technical_indicators as c; print(c.__version__)"` → **1.3.1** (decisive).
- `python -m pytest` → **116 passed**.
- `cargo fmt --all -- --check` → clean.
- Independently **adversarially verified** (release-correctness + scope/gate lenses): no leftover `## [Unreleased]`, both `### Security` entries intact, only the three release files changed, pyo3 still 0.29.0, `pyproject.toml` untouched.

## Changelog
Promoted `## [Unreleased]` → `## [1.3.1] - 2026-06-21`. The consolidated `### Security` (PyO3 + pytest/Pygments) and `### Changed` (rust-version = 1.83) entries carry over unchanged.

## Release / tag — maintainer action
**Merging this PR does not publish.** Publishing is triggered by pushing the **`v1.3.1`** tag on the merge commit, which runs CI's `release` job (`uv publish` to PyPI). That tag push is **maintainer-only** — please tag `v1.3.1` when ready.

_AI assistance: cut with Claude Code (Opus 4.8) in an isolated worktree, then adversarially verified by independent agents; disclosed per CONTRIBUTING.md._
